### PR TITLE
Fix a typo on the `sign` option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -75,7 +75,7 @@ impl ReleaseOpt {
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct ConfigArgs {
-    /// Sign both git commit and tag,
+    /// Sign both git commit and tag
     #[clap(long, overrides_with("no-sign"))]
     sign: bool,
     #[clap(long, overrides_with("sign"), hide(true))]


### PR DESCRIPTION
The current `--help` output looks like:
```
        --isolated
            Ignore implicit configuration files

        --sign
            Sign both git commit and tag,

        --sign-commit
            Sign git commit
```